### PR TITLE
Exit non-zero if the token envvar isn't set

### DIFF
--- a/stats/main.py
+++ b/stats/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from stats import info_statistics
 import settings
@@ -9,7 +10,7 @@ if not settings.PP_TOKEN:
     msg += '{0}/{1} '.format(settings.DATA_GROUP, settings.RESULTS_DATASET)
     msg += 'dataset to run this script. You can get this from '
     msg += 'https://stagecraft.production.performance.service.gov.uk/admin/'
-    print msg
+    sys.exit(msg)
 else:
     c = info_statistics.InfoStatistics(settings.PP_TOKEN)
     c.process_data()


### PR DESCRIPTION
The exit code is 1 when a string is passed to sys.exit, and the string
is sent to stderr.

This should make the Jenkins job know it's failed in this case.
