### PR TITLE
Add logging

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import sys
 
 
 DATA_DOMAIN = os.environ.get(
@@ -10,3 +12,12 @@ PP_TOKEN = os.environ.get('PP_DATASET_TOKEN', None)
 DATA_GROUP = 'govuk-info'
 DAYS = 42
 RESULTS_DATASET = 'info-statistics'
+
+
+logger = logging.getLogger('stats')
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setLevel(logging.INFO)
+
+logger.addHandler(handler)

--- a/settings.py
+++ b/settings.py
@@ -20,4 +20,7 @@ logger.setLevel(logging.INFO)
 handler = logging.StreamHandler(stream=sys.stdout)
 handler.setLevel(logging.INFO)
 
+formatter = logging.Formatter(fmt='%(asctime)s %(message)s')
+handler.setFormatter(formatter)
+
 logger.addHandler(handler)

--- a/settings.py
+++ b/settings.py
@@ -14,11 +14,14 @@ DAYS = 42
 RESULTS_DATASET = 'info-statistics'
 
 
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
+logging_level = getattr(logging, LOG_LEVEL.upper())
+
 logger = logging.getLogger('stats')
-logger.setLevel(logging.INFO)
+logger.setLevel(logging_level)
 
 handler = logging.StreamHandler(stream=sys.stdout)
-handler.setLevel(logging.INFO)
+handler.setLevel(logging_level)
 
 formatter = logging.Formatter(fmt='%(asctime)s %(message)s')
 handler.setFormatter(formatter)

--- a/stats/info_statistics.py
+++ b/stats/info_statistics.py
@@ -316,6 +316,7 @@ class InfoStatistics(object):
         problem_report_counts = self.pp_adapter.get_problem_report_counts()
         search_counts = self.pp_adapter.get_search_counts()
         involved_paths = list(set(problem_report_counts.keys() + search_counts.keys()))
+        involved_paths.sort()
 
         logger.info('Found {} paths to get pageview counts for'.format(len(involved_paths)))
         for path in involved_paths:

--- a/stats/info_statistics.py
+++ b/stats/info_statistics.py
@@ -247,6 +247,7 @@ class PerformancePlatform(object):
         elif filter_by_prefix:
             query_parameters['filter_by_prefix'] = 'pagePath:' + filter_by_prefix
 
+        logger.debug('Getting {0} data with params {1}'.format(dataset_name, query_parameters))
         json_data = dataset.get(query_parameters)
 
         if 'data' in json_data:
@@ -315,6 +316,11 @@ class InfoStatistics(object):
         problem_report_counts = self.pp_adapter.get_problem_report_counts()
         search_counts = self.pp_adapter.get_search_counts()
         involved_paths = list(set(problem_report_counts.keys() + search_counts.keys()))
+
+        logger.info('Found {} paths to get pageview counts for'.format(len(involved_paths)))
+        for path in involved_paths:
+            logger.debug(path)
+
         unique_pageviews = self.pp_adapter.get_unique_pageviews(involved_paths)
 
         dataset.add_unique_pageviews(unique_pageviews)

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 import json
+import logging
 import os
 import re
 import unittest
@@ -15,6 +16,10 @@ from stats.info_statistics import (
     PerformancePlatform,
     SmartAnswer
 )
+
+
+# Prevent info/debug logging cluttering up test output
+logging.disable(logging.INFO)
 
 
 class TestGOVUK(unittest.TestCase):
@@ -361,7 +366,7 @@ class TestInfoStatistics(unittest.TestCase):
                       body='{}',
                       content_type='application/json')
 
-        self.info.process_data(logger=open(os.devnull, 'w'))
+        self.info.process_data()
 
         # we're expecting:
         # - 26 GETs to PP: search terms (one for each letter of the alphabet)


### PR DESCRIPTION
Log to `stdout`, with timestamps:
- `INFO` level (default): a message at the start of each main section of the script. This is helpful for tracking progress, as the full script takes several hours to run
- `DEBUG` level: the params for every `GET` request to the Performance Platform, and a list of all paths we're getting pageview data for

The `INFO` level output looks like this (timestamps are close together because I temporarily disabled most of the requests):

```
2015-04-21 15:52:38,387 Getting smart answers
2015-04-21 15:52:38,914 Loading performance data
2015-04-21 15:52:38,915 Getting problem report counts
2015-04-21 15:53:50,550 Getting search counts
2015-04-21 15:54:27,162 Found 6674 paths to get pageview counts for
2015-04-21 15:54:27,172 Getting pageview counts
2015-04-21 15:54:27,334 Aggregating datapoints
2015-04-21 15:54:27,705 Posting data to Performance Platform
```
