### PR TITLE
Capture log output from all sources in DEBUG mode

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -17,10 +17,16 @@ RESULTS_DATASET = 'info-statistics'
 REPORT_FILENAME = 'report_{}_{}.csv'
 
 
-LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
-logging_level = getattr(logging, LOG_LEVEL.upper())
+LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO').upper()
+logging_level = getattr(logging, LOG_LEVEL)
 
-logger = logging.getLogger('stats')
+# Use the root logger in DEBUG so that we get logged output from the performance
+# platform client; otherwise only use the logger for the stats package
+if LOG_LEVEL == 'DEBUG':
+    logger = logging.getLogger()
+else:
+    logger = logging.getLogger('stats')
+
 logger.setLevel(logging_level)
 
 handler = logging.StreamHandler(stream=sys.stdout)


### PR DESCRIPTION
We've got 400 from PP for the POST request, and the client is logging the
response body, but we didn't see it in our logging because we were only using
the logger for the stats package. Using the root logger when the log level is
set to DEBUG will output all logged messages including those from the PP
client, hopefully letting us see why the POST is failing.
