### PR TITLE
Pin all dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pyOpenSSL==0.13
 pyasn1==0.1.7
 pytz==2013d
 # We also use requests directly to request smartanswers from GOV.UK's search API
-requests==2.6.0
+requests==2.6.2
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,12 @@
+# Dependencies we use directly are commented below
+
+backoff==1.0.3
+ndg-httpsclient==0.3.2
+# We use performanceplatform-client to talk to the Performance Platform
 performanceplatform-client==0.8.2
+pyOpenSSL==0.13
+pyasn1==0.1.7
+pytz==2013d
+# We also use requests directly to request smartanswers from GOV.UK's search API
+requests==2.6.0
+wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 backoff==1.0.3
 ndg-httpsclient==0.3.2
 # We use performanceplatform-client to talk to the Performance Platform
-performanceplatform-client==0.8.2
+performanceplatform-client==0.8.3
 pyOpenSSL==0.13
 pyasn1==0.1.7
 pytz==2013d

--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -1,5 +1,7 @@
+# We use mock, nose and responses directly in tests
 mock==1.0.1
 nose==1.3.6
 responses==0.3.0
+six==1.9.0
 
 -r requirements.txt


### PR DESCRIPTION
Upgrades:
- `requests` to 2.6.2 to avoid an [issue introduced in 2.6.1](https://github.com/kennethreitz/requests/issues/2561), which was [causing errors](https://deploy.preview.alphagov.co.uk/job/run_govuk_complaint_rate_report/8/console) when parsing JSON in responses
- `performanceplatform-client` to 0.8.3 just to stay up-to-date
