### PR TITLE
Upgrade PP client to 0.8.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 backoff==1.0.3
 ndg-httpsclient==0.3.2
 # We use performanceplatform-client to talk to the Performance Platform
-performanceplatform-client==0.8.3
+performanceplatform-client==0.8.5
 pyOpenSSL==0.13
 pyasn1==0.1.7
 pytz==2013d


### PR DESCRIPTION
This brings in retrying of requests on a 500 response, which should help us
get through complete runs of the script rather than erroring on a single 500:

https://github.com/alphagov/performanceplatform-client.py/pull/54
